### PR TITLE
Update matplotlib deprecation warning

### DIFF
--- a/VoigtFit/main.py
+++ b/VoigtFit/main.py
@@ -15,7 +15,7 @@ from VoigtFit import container
 from VoigtFit import io
 
 
-warnings.filterwarnings("ignore", category=matplotlib.mplDeprecation)
+warnings.filterwarnings("ignore", category=matplotlib.MatplotlibDeprecationWarning)
 warnings.filterwarnings("ignore", category=UserWarning)
 
 plt.interactive(True)


### PR DESCRIPTION
Currently throws an error on recent versions of Matplotlib, see e.g. https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/cbook/__init__.py